### PR TITLE
Gravity Aligned Map + ROS REP 105 changes

### DIFF
--- a/src/IMU_Processing.hpp
+++ b/src/IMU_Processing.hpp
@@ -189,9 +189,17 @@ void ImuProcess::IMU_init(const MeasureGroup &meas, esekfom::esekf<state_ikfom, 
 
     N ++;
   }
+
+  /* modified by SanghyunPark - Start */
+  Eigen::Quaterniond rotation = Eigen::Quaterniond::FromTwoVectors(mean_acc, Eigen::Vector3d::UnitZ());
+  mean_acc = rotation * mean_acc;
+  mean_gyr = rotation * mean_gyr;
   state_ikfom init_state = kf_state.get_x();
-  init_state.grav = S2(- mean_acc / mean_acc.norm() * G_m_s2);
-  
+  // init_state.grav = S2(- mean_acc / mean_acc.norm() * G_m_s2);
+  init_state.rot = rotation;
+  init_state.grav = S2(-mean_acc / mean_acc.norm() * G_m_s2);
+  /* modified by SanghyunPark - End */
+
   //state_inout.rot = Eye3d; // Exp(mean_acc.cross(V3D(0, 0, -1 / scale_gravity)));
   init_state.bg  = mean_gyr;
   init_state.offset_T_L_I = Lidar_T_wrt_IMU;

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -148,9 +148,9 @@ geometry_msgs::msg::Quaternion geoQuat;
 geometry_msgs::msg::PoseStamped msg_body_pose;
 
 // Flag to check whether or not we need to look up the transform.
-bool have_lidar_base_link_tf{false};
+bool have_lidar_body_frame_tf{false};
 // Cached lidar_link_from_base_link transform
-geometry_msgs::msg::TransformStamped tf_lidar_link_from_base_link;
+geometry_msgs::msg::TransformStamped tf_lidar_link_from_body_frame;
 std::string lidar_link_frame_id{"lidar_frame"};
 
 
@@ -645,23 +645,23 @@ void set_posestamp(T & out)
     
 }
 
-bool get_lidar_from_base_link_tf(
+bool get_lidar_link_from_body_frame_tf(
     geometry_msgs::msg::TransformStamped &transform,
     std::unique_ptr<tf2_ros::Buffer> & tf_buffer)
 {
     // If we have not already looked up the transform, try to look it up.
-    if (!have_lidar_base_link_tf) {
+    if (!have_lidar_body_frame_tf) {
         try {
-            tf_lidar_link_from_base_link = tf_buffer->lookupTransform(lidar_link_frame_id, body_frame_id, tf2::TimePointZero);
+            tf_lidar_link_from_body_frame = tf_buffer->lookupTransform(lidar_link_frame_id, body_frame_id, tf2::TimePointZero);
             // If the lookup was successful, set the flag so that we don't look it up again.
-            have_lidar_base_link_tf = true;
+            have_lidar_body_frame_tf = true;
         } catch (const tf2::TransformException &ex) {
             std::cerr << "Failed to look up transform from " << body_frame_id << " to " << lidar_link_frame_id << std::endl;
             return false;
         }
     }
     // If we already had it, or if the lookup was successful, we'll set it and return success.
-    transform = tf_lidar_link_from_base_link;
+    transform = tf_lidar_link_from_body_frame;
     return true;
 }
 
@@ -670,77 +670,110 @@ void publish_odometry(
     std::unique_ptr<tf2_ros::TransformBroadcaster> & tf_br,
     std::unique_ptr<tf2_ros::Buffer> & tf_buffer)
 {
-    odomAftMapped.header.frame_id = local_frame_id;
-    odomAftMapped.child_frame_id = lidar_link_frame_id;
-    odomAftMapped.header.stamp = get_ros_time(lidar_end_time);
-    set_posestamp(odomAftMapped.pose);
-    pubOdomAftMapped->publish(odomAftMapped);
+    // Populate msg_body_pose with the current lidar/IMU pose in the local frame.
+    set_posestamp(msg_body_pose);
+    msg_body_pose.header.stamp = get_ros_time(lidar_end_time);
+    msg_body_pose.header.frame_id = local_frame_id;
+
+    // Build local_frame->lidar_link transform from the current state estimate.
+    geometry_msgs::msg::TransformStamped tf_local_frame_from_lidar_link;
+    tf_local_frame_from_lidar_link.header.frame_id = local_frame_id;
+    tf_local_frame_from_lidar_link.header.stamp = msg_body_pose.header.stamp;
+    tf_local_frame_from_lidar_link.child_frame_id = lidar_link_frame_id;
+    tf_local_frame_from_lidar_link.transform.translation.x = msg_body_pose.pose.position.x;
+    tf_local_frame_from_lidar_link.transform.translation.y = msg_body_pose.pose.position.y;
+    tf_local_frame_from_lidar_link.transform.translation.z = msg_body_pose.pose.position.z;
+    tf_local_frame_from_lidar_link.transform.rotation = msg_body_pose.pose.orientation;
+
+    // Look up the static lidar_link->body_frame mount transform.
+    geometry_msgs::msg::TransformStamped tf_lidar_link_from_body_frame;
+    if (!get_lidar_link_from_body_frame_tf(tf_lidar_link_from_body_frame, tf_buffer)) {
+        static rclcpp::Clock clock(RCL_STEADY_TIME);
+        RCLCPP_WARN_THROTTLE(rclcpp::get_logger("fast_lio"), clock, 1000,
+            "%s -> %s TF not yet available; skipping odometry and TF publish.",
+            lidar_link_frame_id.c_str(), body_frame_id.c_str());
+        return;
+    }
+
+    // Compose: local_frame->lidar_link * lidar_link->body_frame = local_frame->body_frame
+    tf2::Transform tf2_local_frame_from_lidar_link;
+    tf2::Transform tf2_lidar_link_from_body_frame;
+    tf2::fromMsg(tf_local_frame_from_lidar_link.transform, tf2_local_frame_from_lidar_link);
+    tf2::fromMsg(tf_lidar_link_from_body_frame.transform, tf2_lidar_link_from_body_frame);
+
+    geometry_msgs::msg::TransformStamped tf_local_frame_from_body_frame;
+    tf_local_frame_from_body_frame.header.frame_id = local_frame_id;
+    tf_local_frame_from_body_frame.header.stamp = msg_body_pose.header.stamp;
+    tf_local_frame_from_body_frame.child_frame_id = body_frame_id;
+    tf_local_frame_from_body_frame.transform = tf2::toMsg(tf2_local_frame_from_lidar_link * tf2_lidar_link_from_body_frame);
+
+    tf_br->sendTransform(tf_local_frame_from_body_frame);
+
+    // Publish odometry reporting the body_frame pose in the local frame.
+    nav_msgs::msg::Odometry odom_local_frame_from_body_frame;
+    odom_local_frame_from_body_frame.header.frame_id = local_frame_id;
+    odom_local_frame_from_body_frame.header.stamp = msg_body_pose.header.stamp;
+    odom_local_frame_from_body_frame.child_frame_id = body_frame_id;
+    odom_local_frame_from_body_frame.pose.pose.position.x = tf_local_frame_from_body_frame.transform.translation.x;
+    odom_local_frame_from_body_frame.pose.pose.position.y = tf_local_frame_from_body_frame.transform.translation.y;
+    odom_local_frame_from_body_frame.pose.pose.position.z = tf_local_frame_from_body_frame.transform.translation.z;
+    odom_local_frame_from_body_frame.pose.pose.orientation = tf_local_frame_from_body_frame.transform.rotation;
     auto P = kf.get_P();
     for (int i = 0; i < 6; i ++)
     {
         int k = i < 3 ? i + 3 : i - 3;
-        odomAftMapped.pose.covariance[i*6 + 0] = P(k, 3);
-        odomAftMapped.pose.covariance[i*6 + 1] = P(k, 4);
-        odomAftMapped.pose.covariance[i*6 + 2] = P(k, 5);
-        odomAftMapped.pose.covariance[i*6 + 3] = P(k, 0);
-        odomAftMapped.pose.covariance[i*6 + 4] = P(k, 1);
-        odomAftMapped.pose.covariance[i*6 + 5] = P(k, 2);
+        odom_local_frame_from_body_frame.pose.covariance[i*6 + 0] = P(k, 3);
+        odom_local_frame_from_body_frame.pose.covariance[i*6 + 1] = P(k, 4);
+        odom_local_frame_from_body_frame.pose.covariance[i*6 + 2] = P(k, 5);
+        odom_local_frame_from_body_frame.pose.covariance[i*6 + 3] = P(k, 0);
+        odom_local_frame_from_body_frame.pose.covariance[i*6 + 4] = P(k, 1);
+        odom_local_frame_from_body_frame.pose.covariance[i*6 + 5] = P(k, 2);
     }
-
-    geometry_msgs::msg::TransformStamped tf_odom_from_lidar_link;
-    tf_odom_from_lidar_link.header.frame_id = local_frame_id;
-    tf_odom_from_lidar_link.header.stamp = odomAftMapped.header.stamp;
-    tf_odom_from_lidar_link.child_frame_id = lidar_link_frame_id;
-    tf_odom_from_lidar_link.transform.translation.x = odomAftMapped.pose.pose.position.x;
-    tf_odom_from_lidar_link.transform.translation.y = odomAftMapped.pose.pose.position.y;
-    tf_odom_from_lidar_link.transform.translation.z = odomAftMapped.pose.pose.position.z;
-    tf_odom_from_lidar_link.transform.rotation.w = odomAftMapped.pose.pose.orientation.w;
-    tf_odom_from_lidar_link.transform.rotation.x = odomAftMapped.pose.pose.orientation.x;
-    tf_odom_from_lidar_link.transform.rotation.y = odomAftMapped.pose.pose.orientation.y;
-    tf_odom_from_lidar_link.transform.rotation.z = odomAftMapped.pose.pose.orientation.z;
-
-    // Compose the odom_from_lidar_link transform above with the lidar_link_from_base_link transform
-    // to compute the odom_from_base_link transform, which we will then publish.
-    geometry_msgs::msg::TransformStamped tf_odom_from_base_link;
-    geometry_msgs::msg::TransformStamped tf_lidar_link_from_base_link;
-
-    if(get_lidar_from_base_link_tf(tf_lidar_link_from_base_link, tf_buffer)) {
-
-        // 1. Convert geometry_msgs to tf2::Transform objects
-        tf2::Transform tf2_odom_from_lidar;
-        tf2::Transform tf2_lidar_from_base;
-
-        tf2::fromMsg(tf_odom_from_lidar_link.transform, tf2_odom_from_lidar);
-        tf2::fromMsg(tf_lidar_link_from_base_link.transform, tf2_lidar_from_base);
-
-        // 2. Compose the transforms (Order matters: Odom->Lidar * Lidar->Base = Odom->Base)
-        tf2::Transform tf2_odom_from_base = tf2_odom_from_lidar * tf2_lidar_from_base;
-
-        // 3. Convert back to geometry_msgs
-        tf_odom_from_base_link.transform = tf2::toMsg(tf2_odom_from_base);
-
-        // Fill out the rest of the transform metadata
-        tf_odom_from_base_link.header.frame_id = tf_odom_from_lidar_link.header.frame_id; // "odom"
-        tf_odom_from_base_link.header.stamp = tf_odom_from_lidar_link.header.stamp;
-        tf_odom_from_base_link.child_frame_id = body_frame_id;
-
-        tf_br->sendTransform(tf_odom_from_base_link);
-    }
-
+    pubOdomAftMapped->publish(odom_local_frame_from_body_frame);
 }
 
 void publish_path(rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pubPath)
 {
+    if (!have_lidar_body_frame_tf) {
+        static rclcpp::Clock clock(RCL_STEADY_TIME);
+        RCLCPP_WARN_THROTTLE(rclcpp::get_logger("fast_lio"), clock, 1000,
+            "%s -> %s TF not yet available; skipping path publish.",
+            lidar_link_frame_id.c_str(), body_frame_id.c_str());
+        return;
+    }
+
+    // Populate msg_body_pose with the current lidar/IMU pose in the local frame.
     set_posestamp(msg_body_pose);
-    msg_body_pose.header.stamp = get_ros_time(lidar_end_time); // ros::Time().fromSec(lidar_end_time);
+    msg_body_pose.header.stamp = get_ros_time(lidar_end_time);
     msg_body_pose.header.frame_id = local_frame_id;
+
+    // Transform the lidar pose to the body_frame pose using the cached mount transform.
+    geometry_msgs::msg::Transform local_frame_from_lidar_link_tf;
+    local_frame_from_lidar_link_tf.translation.x = msg_body_pose.pose.position.x;
+    local_frame_from_lidar_link_tf.translation.y = msg_body_pose.pose.position.y;
+    local_frame_from_lidar_link_tf.translation.z = msg_body_pose.pose.position.z;
+    local_frame_from_lidar_link_tf.rotation = msg_body_pose.pose.orientation;
+
+    tf2::Transform tf2_local_frame_from_lidar_link;
+    tf2::Transform tf2_lidar_link_from_body_frame;
+    tf2::fromMsg(local_frame_from_lidar_link_tf, tf2_local_frame_from_lidar_link);
+    tf2::fromMsg(tf_lidar_link_from_body_frame.transform, tf2_lidar_link_from_body_frame);
+    geometry_msgs::msg::Transform local_frame_from_body_frame_tf = tf2::toMsg(tf2_local_frame_from_lidar_link * tf2_lidar_link_from_body_frame);
+
+    geometry_msgs::msg::PoseStamped body_pose;
+    body_pose.header.stamp = msg_body_pose.header.stamp;
+    body_pose.header.frame_id = local_frame_id;
+    body_pose.pose.position.x = local_frame_from_body_frame_tf.translation.x;
+    body_pose.pose.position.y = local_frame_from_body_frame_tf.translation.y;
+    body_pose.pose.position.z = local_frame_from_body_frame_tf.translation.z;
+    body_pose.pose.orientation = local_frame_from_body_frame_tf.rotation;
 
     /*** if path is too large, the rvis will crash ***/
     static int jjj = 0;
     jjj++;
-    if (jjj % 10 == 0) 
+    if (jjj % 10 == 0)
     {
-        path.poses.push_back(msg_body_pose);
+        path.poses.push_back(body_pose);
         pubPath->publish(path);
     }
 }

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -57,6 +57,9 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <livox_ros_driver2/msg/custom_msg.hpp>
@@ -139,6 +142,13 @@ nav_msgs::msg::Path path;
 nav_msgs::msg::Odometry odomAftMapped;
 geometry_msgs::msg::Quaternion geoQuat;
 geometry_msgs::msg::PoseStamped msg_body_pose;
+
+// Flag to check whether or not we need to look up the transform.
+bool have_lidar_base_link_tf{false};
+// Cached lidar_link_from_base_link transform
+geometry_msgs::msg::TransformStamped tf_lidar_link_from_base_link;
+std::string lidar_link_frame_id{"lidar_frame"};
+
 
 shared_ptr<Preprocess> p_pre(new Preprocess());
 shared_ptr<ImuProcess> p_imu(new ImuProcess());
@@ -282,6 +292,9 @@ void lasermap_fov_segment()
 
 void standard_pcl_cbk(const sensor_msgs::msg::PointCloud2::UniquePtr msg) 
 {
+    // Set lidar link frame id
+    lidar_link_frame_id = msg->header.frame_id;
+
     mtx_buffer.lock();
     scan_count ++;
     double cur_time = get_time_sec(msg->header.stamp);
@@ -310,6 +323,9 @@ double timediff_lidar_wrt_imu = 0.0;
 bool   timediff_set_flg = false;
 void livox_pcl_cbk(const livox_ros_driver2::msg::CustomMsg::UniquePtr msg) 
 {
+    // Set lidar link frame id
+    lidar_link_frame_id = msg->header.frame_id;
+
     mtx_buffer.lock();
     double cur_time = get_time_sec(msg->header.stamp);
     double preprocess_start_time = omp_get_wtime();
@@ -505,7 +521,7 @@ void publish_frame_world(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::Share
         pcl::toROSMsg(*laserCloudWorld, laserCloudmsg);
         // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
         laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-        laserCloudmsg.header.frame_id = "camera_init";
+        laserCloudmsg.header.frame_id = "odom";
         pubLaserCloudFull->publish(laserCloudmsg);
         publish_count -= PUBFRAME_PERIOD;
     }
@@ -557,7 +573,7 @@ void publish_frame_body(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::Shared
     sensor_msgs::msg::PointCloud2 laserCloudmsg;
     pcl::toROSMsg(*laserCloudIMUBody, laserCloudmsg);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudmsg.header.frame_id = "body";
+    laserCloudmsg.header.frame_id = lidar_link_frame_id;
     pubLaserCloudFull_body->publish(laserCloudmsg);
     publish_count -= PUBFRAME_PERIOD;
 }
@@ -574,7 +590,7 @@ void publish_effect_world(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::Shar
     sensor_msgs::msg::PointCloud2 laserCloudFullRes3;
     pcl::toROSMsg(*laserCloudWorld, laserCloudFullRes3);
     laserCloudFullRes3.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudFullRes3.header.frame_id = "camera_init";
+    laserCloudFullRes3.header.frame_id = "odom";
     pubLaserCloudEffect->publish(laserCloudFullRes3);
 }
 
@@ -596,13 +612,13 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
     pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
     // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudmsg.header.frame_id = "camera_init";
+    laserCloudmsg.header.frame_id = "odom";
     pubLaserCloudMap->publish(laserCloudmsg);
 
     // sensor_msgs::msg::PointCloud2 laserCloudMap;
     // pcl::toROSMsg(*featsFromMap, laserCloudMap);
     // laserCloudMap.header.stamp = get_ros_time(lidar_end_time);
-    // laserCloudMap.header.frame_id = "camera_init";
+    // laserCloudMap.header.frame_id = "odom";
     // pubLaserCloudMap->publish(laserCloudMap);
 }
 
@@ -625,10 +641,33 @@ void set_posestamp(T & out)
     
 }
 
-void publish_odometry(const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pubOdomAftMapped, std::unique_ptr<tf2_ros::TransformBroadcaster> & tf_br)
+bool get_lidar_from_base_link_tf(
+    geometry_msgs::msg::TransformStamped &transform,
+    std::unique_ptr<tf2_ros::Buffer> & tf_buffer)
 {
-    odomAftMapped.header.frame_id = "camera_init";
-    odomAftMapped.child_frame_id = "body";
+    // If we have not already looked up the transform, try to look it up.
+    if (!have_lidar_base_link_tf) {
+        try {
+            tf_lidar_link_from_base_link = tf_buffer->lookupTransform(lidar_link_frame_id, "base_link", tf2::TimePointZero);
+            // If the lookup was successful, set the flag so that we don't look it up again.
+            have_lidar_base_link_tf = true;
+        } catch (const tf2::TransformException &ex) {
+            std::cerr << "Failed to look up transform from base_link to " << lidar_link_frame_id << std::endl;
+            return false;
+        }
+    }
+    // If we already had it, or if the lookup was successful, we'll set it and return success.
+    transform = tf_lidar_link_from_base_link;
+    return true;
+}
+
+void publish_odometry(
+    const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pubOdomAftMapped,
+    std::unique_ptr<tf2_ros::TransformBroadcaster> & tf_br,
+    std::unique_ptr<tf2_ros::Buffer> & tf_buffer)
+{
+    odomAftMapped.header.frame_id = "odom";
+    odomAftMapped.child_frame_id = lidar_link_frame_id;
     odomAftMapped.header.stamp = get_ros_time(lidar_end_time);
     set_posestamp(odomAftMapped.pose);
     pubOdomAftMapped->publish(odomAftMapped);
@@ -644,25 +683,39 @@ void publish_odometry(const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPt
         odomAftMapped.pose.covariance[i*6 + 5] = P(k, 2);
     }
 
-    geometry_msgs::msg::TransformStamped trans;
-    trans.header.frame_id = "camera_init";
-    trans.header.stamp = odomAftMapped.header.stamp;
-    trans.child_frame_id = "body";
-    trans.transform.translation.x = odomAftMapped.pose.pose.position.x;
-    trans.transform.translation.y = odomAftMapped.pose.pose.position.y;
-    trans.transform.translation.z = odomAftMapped.pose.pose.position.z;
-    trans.transform.rotation.w = odomAftMapped.pose.pose.orientation.w;
-    trans.transform.rotation.x = odomAftMapped.pose.pose.orientation.x;
-    trans.transform.rotation.y = odomAftMapped.pose.pose.orientation.y;
-    trans.transform.rotation.z = odomAftMapped.pose.pose.orientation.z;
-    tf_br->sendTransform(trans);
+    geometry_msgs::msg::TransformStamped tf_odom_from_lidar_link;
+    tf_odom_from_lidar_link.header.frame_id = "odom";
+    tf_odom_from_lidar_link.header.stamp = odomAftMapped.header.stamp;
+    tf_odom_from_lidar_link.child_frame_id = lidar_link_frame_id;
+    tf_odom_from_lidar_link.transform.translation.x = odomAftMapped.pose.pose.position.x;
+    tf_odom_from_lidar_link.transform.translation.y = odomAftMapped.pose.pose.position.y;
+    tf_odom_from_lidar_link.transform.translation.z = odomAftMapped.pose.pose.position.z;
+    tf_odom_from_lidar_link.transform.rotation.w = odomAftMapped.pose.pose.orientation.w;
+    tf_odom_from_lidar_link.transform.rotation.x = odomAftMapped.pose.pose.orientation.x;
+    tf_odom_from_lidar_link.transform.rotation.y = odomAftMapped.pose.pose.orientation.y;
+    tf_odom_from_lidar_link.transform.rotation.z = odomAftMapped.pose.pose.orientation.z;
+
+    // Compose the odom_from_lidar_link transform above with the lidar_link_from_base_link transform
+    // to compute the odom_from_base_link transform, which we will then publish. The
+    // lidar_link_from_base_link transform is looked up from tf.
+    geometry_msgs::msg::TransformStamped tf_odom_from_base_link;
+    geometry_msgs::msg::TransformStamped tf_lidar_link_from_base_link;
+    if(get_lidar_from_base_link_tf(tf_lidar_link_from_base_link, tf_buffer)) {
+        tf2::doTransform(tf_odom_from_lidar_link, tf_odom_from_base_link, tf_lidar_link_from_base_link);
+        // Fill out the rest of the transform
+        tf_odom_from_base_link.header.frame_id = tf_odom_from_lidar_link.header.frame_id;
+        tf_odom_from_base_link.header.stamp = tf_odom_from_lidar_link.header.stamp;
+        tf_odom_from_base_link.child_frame_id = "base_link";
+        tf_br->sendTransform(tf_odom_from_base_link);
+    }
+
 }
 
 void publish_path(rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pubPath)
 {
     set_posestamp(msg_body_pose);
     msg_body_pose.header.stamp = get_ros_time(lidar_end_time); // ros::Time().fromSec(lidar_end_time);
-    msg_body_pose.header.frame_id = "camera_init";
+    msg_body_pose.header.frame_id = "odom";
 
     /*** if path is too large, the rvis will crash ***/
     static int jjj = 0;
@@ -873,7 +926,7 @@ public:
         RCLCPP_INFO(this->get_logger(), "p_pre->lidar_type %d", p_pre->lidar_type);
 
         path.header.stamp = this->get_clock()->now();
-        path.header.frame_id ="camera_init";
+        path.header.frame_id ="odom";
 
         // /*** variables definition ***/
         // int effect_feat_num = 0, frame_num = 0;
@@ -934,6 +987,8 @@ public:
         pubOdomAftMapped_ = this->create_publisher<nav_msgs::msg::Odometry>("/Odometry", 20);
         pubPath_ = this->create_publisher<nav_msgs::msg::Path>("/path", 20);
         tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+        tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
+        tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
 
         //------------------------------------------------------------------------------------------------------
         auto period_ms = std::chrono::milliseconds(static_cast<int64_t>(1000.0 / 100.0));
@@ -1061,7 +1116,7 @@ private:
             double t_update_end = omp_get_wtime();
 
             /******* Publish odometry *******/
-            publish_odometry(pubOdomAftMapped_, tf_broadcaster_);
+            publish_odometry(pubOdomAftMapped_, tf_broadcaster_, tf_buffer_);
 
             /*** add the feature points to map kdtree ***/
             t3 = omp_get_wtime();
@@ -1140,6 +1195,8 @@ private:
     rclcpp::Subscription<livox_ros_driver2::msg::CustomMsg>::SharedPtr sub_pcl_livox_;
 
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
+    std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
     rclcpp::TimerBase::SharedPtr timer_;
     rclcpp::TimerBase::SharedPtr map_pub_timer_;
     rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr map_save_srv_;

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -696,16 +696,30 @@ void publish_odometry(
     tf_odom_from_lidar_link.transform.rotation.z = odomAftMapped.pose.pose.orientation.z;
 
     // Compose the odom_from_lidar_link transform above with the lidar_link_from_base_link transform
-    // to compute the odom_from_base_link transform, which we will then publish. The
-    // lidar_link_from_base_link transform is looked up from tf.
+    // to compute the odom_from_base_link transform, which we will then publish.
     geometry_msgs::msg::TransformStamped tf_odom_from_base_link;
     geometry_msgs::msg::TransformStamped tf_lidar_link_from_base_link;
+
     if(get_lidar_from_base_link_tf(tf_lidar_link_from_base_link, tf_buffer)) {
-        tf2::doTransform(tf_odom_from_lidar_link, tf_odom_from_base_link, tf_lidar_link_from_base_link);
-        // Fill out the rest of the transform
-        tf_odom_from_base_link.header.frame_id = tf_odom_from_lidar_link.header.frame_id;
+
+        // 1. Convert geometry_msgs to tf2::Transform objects
+        tf2::Transform tf2_odom_from_lidar;
+        tf2::Transform tf2_lidar_from_base;
+
+        tf2::fromMsg(tf_odom_from_lidar_link.transform, tf2_odom_from_lidar);
+        tf2::fromMsg(tf_lidar_link_from_base_link.transform, tf2_lidar_from_base);
+
+        // 2. Compose the transforms (Order matters: Odom->Lidar * Lidar->Base = Odom->Base)
+        tf2::Transform tf2_odom_from_base = tf2_odom_from_lidar * tf2_lidar_from_base;
+
+        // 3. Convert back to geometry_msgs
+        tf_odom_from_base_link.transform = tf2::toMsg(tf2_odom_from_base);
+
+        // Fill out the rest of the transform metadata
+        tf_odom_from_base_link.header.frame_id = tf_odom_from_lidar_link.header.frame_id; // "odom"
         tf_odom_from_base_link.header.stamp = tf_odom_from_lidar_link.header.stamp;
         tf_odom_from_base_link.child_frame_id = "base_link";
+
         tf_br->sendTransform(tf_odom_from_base_link);
     }
 

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -89,6 +89,10 @@ condition_variable sig_buffer;
 
 string root_dir = ROOT_DIR;
 string map_file_path, lid_topic, imu_topic;
+// local_frame_id: local, world-fixed, gravity-aligned frame (e.g. "odom")
+// body_frame_id: body-fixed FLU frame level with the robot (e.g. "base_link")
+string local_frame_id = "odom";
+string body_frame_id = "base_link";
 
 double res_mean_last = 0.05, total_residual = 0.0;
 double last_timestamp_lidar = 0, last_timestamp_imu = -1.0;
@@ -521,7 +525,7 @@ void publish_frame_world(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::Share
         pcl::toROSMsg(*laserCloudWorld, laserCloudmsg);
         // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
         laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-        laserCloudmsg.header.frame_id = "odom";
+        laserCloudmsg.header.frame_id = local_frame_id;
         pubLaserCloudFull->publish(laserCloudmsg);
         publish_count -= PUBFRAME_PERIOD;
     }
@@ -590,7 +594,7 @@ void publish_effect_world(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::Shar
     sensor_msgs::msg::PointCloud2 laserCloudFullRes3;
     pcl::toROSMsg(*laserCloudWorld, laserCloudFullRes3);
     laserCloudFullRes3.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudFullRes3.header.frame_id = "odom";
+    laserCloudFullRes3.header.frame_id = local_frame_id;
     pubLaserCloudEffect->publish(laserCloudFullRes3);
 }
 
@@ -612,7 +616,7 @@ void publish_map(rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub
     pcl::toROSMsg(*pcl_wait_pub, laserCloudmsg);
     // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.stamp = get_ros_time(lidar_end_time);
-    laserCloudmsg.header.frame_id = "odom";
+    laserCloudmsg.header.frame_id = local_frame_id;
     pubLaserCloudMap->publish(laserCloudmsg);
 
     // sensor_msgs::msg::PointCloud2 laserCloudMap;
@@ -648,11 +652,11 @@ bool get_lidar_from_base_link_tf(
     // If we have not already looked up the transform, try to look it up.
     if (!have_lidar_base_link_tf) {
         try {
-            tf_lidar_link_from_base_link = tf_buffer->lookupTransform(lidar_link_frame_id, "base_link", tf2::TimePointZero);
+            tf_lidar_link_from_base_link = tf_buffer->lookupTransform(lidar_link_frame_id, body_frame_id, tf2::TimePointZero);
             // If the lookup was successful, set the flag so that we don't look it up again.
             have_lidar_base_link_tf = true;
         } catch (const tf2::TransformException &ex) {
-            std::cerr << "Failed to look up transform from base_link to " << lidar_link_frame_id << std::endl;
+            std::cerr << "Failed to look up transform from " << body_frame_id << " to " << lidar_link_frame_id << std::endl;
             return false;
         }
     }
@@ -666,7 +670,7 @@ void publish_odometry(
     std::unique_ptr<tf2_ros::TransformBroadcaster> & tf_br,
     std::unique_ptr<tf2_ros::Buffer> & tf_buffer)
 {
-    odomAftMapped.header.frame_id = "odom";
+    odomAftMapped.header.frame_id = local_frame_id;
     odomAftMapped.child_frame_id = lidar_link_frame_id;
     odomAftMapped.header.stamp = get_ros_time(lidar_end_time);
     set_posestamp(odomAftMapped.pose);
@@ -684,7 +688,7 @@ void publish_odometry(
     }
 
     geometry_msgs::msg::TransformStamped tf_odom_from_lidar_link;
-    tf_odom_from_lidar_link.header.frame_id = "odom";
+    tf_odom_from_lidar_link.header.frame_id = local_frame_id;
     tf_odom_from_lidar_link.header.stamp = odomAftMapped.header.stamp;
     tf_odom_from_lidar_link.child_frame_id = lidar_link_frame_id;
     tf_odom_from_lidar_link.transform.translation.x = odomAftMapped.pose.pose.position.x;
@@ -718,7 +722,7 @@ void publish_odometry(
         // Fill out the rest of the transform metadata
         tf_odom_from_base_link.header.frame_id = tf_odom_from_lidar_link.header.frame_id; // "odom"
         tf_odom_from_base_link.header.stamp = tf_odom_from_lidar_link.header.stamp;
-        tf_odom_from_base_link.child_frame_id = "base_link";
+        tf_odom_from_base_link.child_frame_id = body_frame_id;
 
         tf_br->sendTransform(tf_odom_from_base_link);
     }
@@ -729,7 +733,7 @@ void publish_path(rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pubPath)
 {
     set_posestamp(msg_body_pose);
     msg_body_pose.header.stamp = get_ros_time(lidar_end_time); // ros::Time().fromSec(lidar_end_time);
-    msg_body_pose.header.frame_id = "odom";
+    msg_body_pose.header.frame_id = local_frame_id;
 
     /*** if path is too large, the rvis will crash ***/
     static int jjj = 0;
@@ -900,6 +904,8 @@ public:
         this->declare_parameter<int>("pcd_save.interval", -1);
         this->declare_parameter<vector<double>>("mapping.extrinsic_T", vector<double>());
         this->declare_parameter<vector<double>>("mapping.extrinsic_R", vector<double>());
+        this->declare_parameter<string>("local_frame_id", "odom");
+        this->declare_parameter<string>("body_frame_id", "base_link");
 
         this->get_parameter_or<bool>("publish.path_en", path_en, true);
         this->get_parameter_or<bool>("publish.effect_map_en", effect_pub_en, false);
@@ -936,11 +942,13 @@ public:
         this->get_parameter_or<int>("pcd_save.interval", pcd_save_interval, -1);
         this->get_parameter_or<vector<double>>("mapping.extrinsic_T", extrinT, vector<double>());
         this->get_parameter_or<vector<double>>("mapping.extrinsic_R", extrinR, vector<double>());
+        this->get_parameter_or<string>("local_frame_id", local_frame_id, "odom");
+        this->get_parameter_or<string>("body_frame_id", body_frame_id, "base_link");
 
         RCLCPP_INFO(this->get_logger(), "p_pre->lidar_type %d", p_pre->lidar_type);
 
         path.header.stamp = this->get_clock()->now();
-        path.header.frame_id ="odom";
+        path.header.frame_id = local_frame_id;
 
         // /*** variables definition ***/
         // int effect_feat_num = 0, frame_num = 0;


### PR DESCRIPTION
Hi there,

I added some changes to make FAST-LIO2 a bit more plug-and-play for ROS2 systems that conform to [ROS REP 105](https://www.ros.org/reps/rep-0105.html). Namely:

1. Added gravity alignment changes from [this repo](https://github.com/hku-mars/FAST_LIO/compare/main...SanghyunPark01:FAST_LIO_gravity_align:main), so that the roll and pitch of the sensor's first measurement is accounted for in the transform chain. This way, the resulting map will be gravity aligned, and the odometry outputs will be w.r.t. a gravity aligned local frame. _Note: This change has nothing to do with ROS REP 105--more just a quality-of-life feature that you find in other estimators. VINS-Mono does this, to cite another example._ All credit here goes to @SanghyunPark01
2. Updated the node to publish the `odom_from_**base_link**" transform, instead of `odom_from_lidar_link` -- which is necessary for FAST-LIO to serve as a ROS REP 105 compliant local estimator. Without this, your lidar's link will end up having two parents: `base_link` and `odom` (assuming you have your URDF set up according to REP 105 and REP 103). Some helpful context for why this is important can be found in [these instructions](https://docs.nav2.org/setup_guides/urdf/setup_urdf.html) from Nav2.

I recognize that none of these changes are strictly relevant to FAST-LIO as an odometry system. However, I would argue that these changes _are_ important/useful for this module to fit into / be usable in ROS projects / projects that follow some of these conventions.

I tested these changes on a personal dataset of mine, but may be able to provide further validation if desired.